### PR TITLE
doc: correct .env.local code docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install
 
 Create a .env.local file:
 
-NEXT_PUBLIC_GITHUB_TOKEN=your_github_token
+GITHUB_TOKEN=your_github_token
 
 
 Using a token helps avoid GitHub API rate limits.


### PR DESCRIPTION
Just deleted the "NEXT_PUBLIC" from `NEXT_PUBLIC_GITHUB_TOKEN=your_github_token`

This solves [[Issue]: wrong-token-doc](https://github.com/shreyashpatel5506/gitprofileAi/issues/18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variable configuration instructions in the Getting Started section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->