### PR TITLE
feat/shareable link

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -127,7 +127,7 @@ const HomePage = () => {
             </p>
 
             <div className="w-full max-w-md">
-              <SearchBar onSearch={handleSearch}/>
+              <SearchBar onSearch={handleSearch} />
             </div>
 
             {error && (
@@ -169,7 +169,7 @@ const HomePage = () => {
                   <MiniStat label="Repos" value={data.profile.publicRepos} />
                 </div>
               </div>
-              <button onClick={() => setSharing(!sharing)} className="self-start bg-indigo-600 p-2 rounded-xl"><Share /></button>
+              <button aria-label="Share profile" onClick={() => setSharing(!sharing)} className="self-start bg-indigo-600 p-2 rounded-xl"><Share /></button>
               {sharing && (
                 <>
                   <div


### PR DESCRIPTION
Implemented an very basic profile sharing feature. 
This is a very basic solution for this feature. Later this should be updated by moving the after analysis part into an dynamic folder. 
For now this works like this:

1. when a user searches for a profile the user will be written in the url
2. when a user shares his profile the user param will be in the url
3. when another user opens this the app will check for the user param in the url and fetch the data from the url user

This (FOR NOW) solves [[Issue]: Add profile shareable link](https://github.com/shreyashpatel5506/gitprofileAi/issues/1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Share modal to copy/share the current profile URL, consistent across Profile and AI Analysis sections.
  * Direct profile loading from URL parameters for bookmarking/linking.
  * Searches update the URL and navigate programmatically so results are shareable and restorable.

* **Minor Changes**
  * Preserved AI Analysis rendering and PDF download; unified modal layout and interaction for sharing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->