### PR TITLE
fix: add localstorage user to url when no user provided

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -35,7 +35,11 @@ const HomePage = () => {
     } else {
       let storedUser = localStorage.getItem("githubData");
       storedUser = JSON.parse(storedUser);
-      router.push(`?user=${storedUser.profile.username}`, { scroll: false });
+      if (localStorage.getItem("githubData") == undefined || !storedUser) {
+        return;
+      } else {
+        router.push(`?user=${storedUser.profile.username}`, { scroll: false });
+      }
     }
   }, []);
 


### PR DESCRIPTION
**fixed the shareable-link feature**

The problem is described in [[Issue]: fix shareable link](https://github.com/shreyashpatel5506/gitprofileAi/issues/22)

**Solution:**
just checking for a user param in the url, if this is not provided the username will be fetched from the localstorage and will be added to the url username param

@shreyashpatel5506 review required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The app now automatically restores your previously viewed GitHub profile when you visit without a username in the URL, using cached session data to redirect you back to the correct profile.
  * If cached profile data is missing or invalid, the app will remain on the current page without forcing a redirect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->